### PR TITLE
add ad-hoc mock por usePArams in GetCheck test

### DIFF
--- a/burguer-queen/src/components/GetCheck/GetCheck.test.js
+++ b/burguer-queen/src/components/GetCheck/GetCheck.test.js
@@ -3,12 +3,18 @@ import { render, fireEvent } from '@testing-library/react';
 import GetCheck from './GetCheck';
 import { showInfoTables } from "../../controllers";
 
-test('renders learn react link',() => {
-   
-     const { getByRole, getByTestId } = render(<GetCheck {id ="FCKFCS5LrLkKGMbQ8UCp" }/>);
-    const btnCheck= getByTestId("btnCheck")
-    fireEvent.click(btnCheck)
-    await waitForElement(() => getByTestId("modalCheck"));
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({
+    id: 'FCKFCS5LrLkKGMbQ8UCp',
+  }),
+}));
+
+test('renders learn react link', async () => {
+  const { getByRole, getByTestId } = render(<GetCheck />);
+  const btnCheck= getByTestId("btnCheck")
+  fireEvent.click(btnCheck)
+  await waitForElement(() => getByTestId("modalCheck"));
   const check = getByRole("modal");
-    expect(check).toBeInTheDocument();
-  });
+  expect(check).toBeInTheDocument();
+});


### PR DESCRIPTION
@shari12 @danleonca no funcionaba porque estaba mockeando mal `useParams` (retorna un objecto, con la propieda `id`, yo estaba retornando un string)

Ahora hice lo mismo q intente en la maniana, pero con el mock localmente en el test, para q aplique solamente para este componente.

Fijense q cuando corren el test, ya no falla, pero pasan 2 cosas:
- hay un promise q falla no lo estan controlando (creo q es en `showInfoTables` -hay un `await` sin `try/catch` y creo q es porque estan intentando de usar firebase sin iniciarlo). Deberian o bien [mockear firebase](https://github.com/mikkopaderes/mock-cloud-firestore) o mockear `showInfoTables`